### PR TITLE
Fix sloped glass transparency

### DIFF
--- a/tiles/materials/avalislopedaerogelglass.material
+++ b/tiles/materials/avalislopedaerogelglass.material
@@ -14,7 +14,7 @@
   "renderParameters" : {
     "texture" : "avalislopedaerogelglass.png",
     "variants" : 1,
-    "lightTransparent" : false,
+    "lightTransparent" : true,
     "occludesBelow" : false,
     "multiColored" : true,
     "zLevel" : 4998


### PR DESCRIPTION
Extremely minor change. The Sloped Glass variant for some reason had its light transparency turned off.