### PR TITLE
Fixed grammatical error in dialog/guard.config.patch

### DIFF
--- a/dialog/guard.config.patch
+++ b/dialog/guard.config.patch
@@ -5,7 +5,7 @@
     "value" : {  
       "default" : [  
         "Hi there, stranger!",
-        "*hums to themself*",
+        "*Hums to themselves*",
         "Welcome to our town, traveller.",
         "Perimeter secure."
       ]


### PR DESCRIPTION
Changed "*hums to themself*" to "*Hums to themselves*" given that "them" is a plural pronoun