### PR TITLE
Fixed grammatical error in npcs/guard.config.patch

### DIFF
--- a/npcs/guard.config.patch
+++ b/npcs/guard.config.patch
@@ -5,7 +5,7 @@
     "value" : {  
       "default" : [  
         "Hi there stranger~",
-        "*Hums to themself*",
+        "*Hums to themselves*",
         "Welcome to our town, traveller.",
         "Perimeter secure."
       ],


### PR DESCRIPTION
Changed "*Hums to themself*" to "*Hums to themselves*" given that "them" is a plural pronoun