### PR TITLE
Bugfix: Add tag "sniperrifle" to avalisniper

### DIFF
--- a/items/active/weapons/ranged/tiered/sniper/avalisniper.activeitem
+++ b/items/active/weapons/ranged/tiered/sniper/avalisniper.activeitem
@@ -9,7 +9,7 @@
   "level" : 1,
   "tooltipKind" : "avalichitsnipui",
   "category" : "sniperRifle",
-  "itemTags" : ["weapon","ranged","rifle"],
+  "itemTags" : ["weapon","ranged","rifle","sniperrifle"],
   "twoHanded" : true,
   
   "animation" : "/items/active/weapons/ranged/gun.animation",


### PR DESCRIPTION
While playing with FU I realised that the armour effects for sniper rifles weren't applied. This simply adds the tag required to make it work.