### PR TITLE
Bugfix: Typo in converse.config.patch avakin -> avikan

### DIFF
--- a/dialog/converse.config.patch
+++ b/dialog/converse.config.patch
@@ -518,7 +518,7 @@
     },
     {
       "op": "add",
-      "path": "/converse/avakin/avali",
+      "path": "/converse/avikan/avali",
       "value": [
         "Greetings, Avali.",
         "We know what a war of extermination feels like. You have our sympathies.",


### PR DESCRIPTION
I saw this in my log while playing as Avali:

> [18:22:18.608] [Error] Could not apply patch from file /dialog/converse.config.patch in source: ../mods/Avali Triage-17-06-2021.pak.  Caused by: (JsonPatchException) Could not apply patch to base. (JsonPatchException) Could not apply operation to base. (TraversalException) No such key 'avakin' in pathApply("/converse/avakin/avali")

It popped up randomly and often in the log. I realised that there was a little typo in the patch file, it's not av**a**k**i**n but av**i**k**a**n :-D