### PR TITLE
Bugfix: Missing colony tag "bed" on all the Avali beds

### DIFF
--- a/objects/avalicamp/cushions/avalicushion2.object
+++ b/objects/avalicamp/cushions/avalicushion2.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "avalicushion2",
-  "colonyTags" : [ "avali", "avalicamp" ],
+  "colonyTags" : [ "avali", "avalicamp", "bed" ],
   "itemTags" : ["coloriser"],
   "rarity" : "Common",
   "category" : "furniture",

--- a/objects/avalicamp/hammocks/avalihammock1.object
+++ b/objects/avalicamp/hammocks/avalihammock1.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "avalihammock1",
-  "colonyTags" : [ "avali", "avalicamp" ],
+  "colonyTags" : [ "avali", "avalicamp", "bed" ],
   "itemTags" : ["coloriser"],
   "printable" : true,
   "rarity" : "Common",

--- a/objects/avaligeneric/beds/avalichamber1.object
+++ b/objects/avaligeneric/beds/avalichamber1.object
@@ -1,6 +1,6 @@
 {
   "objectName" : "avalichamber1",
-  "colonyTags" : [ "avali", "avalicamp" ],
+  "colonyTags" : [ "avali", "avalicamp", "bed" ],
   "itemTags" : ["coloriser"],
   "printable" : true,
   "rarity" : "Common",


### PR DESCRIPTION
Fixes the 3 beds that exists in this mod, so that they can be used in FU colonies/ships (avalichamber1.object  is not fixed by the Avali Triage FU patch!)