### PR TITLE
Merging our mods' Saturnian to Avali dialog

### DIFF
--- a/dialog/converse.config.patch
+++ b/dialog/converse.config.patch
@@ -631,10 +631,15 @@
       "op": "add",
       "path": "/converse/saturn/avali",
       "value": [
+        "Hello traveler. Uh... Have you been working with ammonia recently?",
+        "Aerogel sounds like a useful material. Do you know of any books that detail how to make it?",
+        "Huh? Are you an Avali? You are much taller than my guide book said you would be.",
+        "You are really fluffy and feathery. Are you warm-blooded as well?",
+        "You're really different from the other species I usually see around here. You must have traveled far.",
         "Hello, Avali.",
         "You have beautiful wings.",
         "I like your plumage.",
-        "Aww, how cute! (squeaking)",
+        "Aww, how cute! Squeak!",
         "Might I borrow a feather? I need it for a spell I'm working on..."
       ]
     },
@@ -642,10 +647,15 @@
       "op": "add",
       "path": "/converse/saturn2/avali",
       "value": [
+        "Hello traveler. Uh... Have you been working with ammonia recently?",
+        "Do you know of any books I could read about the strange plants from your homeworld?",
+        "Huh? Are you an Avali? You are much taller than my guide book said you would be.",
+        "Your species has been known to modify itself quite a bit. Did your species modify other species from your world as well?",
+        "Aeroponics is an interesting approach to gardening.",
         "Hello, Avali.",
         "You have beautiful wings.",
         "I like your plumage.",
-        "Aww, how cute! (squeaking)",
+        "Aww, how cute! Squeak!",
         "Might I borrow a feather? I need it for a spell I'm working on..."
       ]
     }


### PR DESCRIPTION
I noticed this quite a bit late, but Saturnians and Avali have a small conflict: both of our mods are trying to patch in dialog for when Saturnian villagers speak to Avali players. So here, I have taken my Avali-related dialog, and merged it with the dialog in the Avali mod.