### PR TITLE
Add missing rarity buttons to avaliloom and avalidisplayapparatus

### DIFF
--- a/interface/windowconfig/avalidisplayapparatus.config
+++ b/interface/windowconfig/avalidisplayapparatus.config
@@ -195,6 +195,38 @@
       "type" : "radioGroup",
       "toggleMode" : true,
       "buttons" : [
+        {
+          "position" : [6, 60],
+          "baseImage" : "/interface/crafting/sortcommon.png",
+          "baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+          "data" : {
+            "rarity" : [ "common" ]
+          }
+        },
+        {
+          "position" : [12, 60],
+          "baseImage" : "/interface/crafting/sortuncommon.png",
+          "baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+          "data" : {
+            "rarity" : [ "uncommon" ]
+          }
+        },
+        {
+          "position" : [18, 60],
+          "baseImage" : "/interface/crafting/sortrare.png",
+          "baseImageChecked" : "/interface/crafting/sortrareselected.png",
+          "data" : {
+            "rarity" : [ "rare" ]
+          }
+        },
+        {
+          "position" : [24, 60],
+          "baseImage" : "/interface/crafting/sortlegendary.png",
+          "baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+          "data" : {
+            "rarity" : [ "legendary" ]
+          }
+        }
       ]
     }
   }

--- a/interface/windowconfig/avaliloom.config
+++ b/interface/windowconfig/avaliloom.config
@@ -247,6 +247,38 @@
       "type" : "radioGroup",
       "toggleMode" : true,
       "buttons" : [
+        {
+          "position" : [6, 60],
+          "baseImage" : "/interface/crafting/sortcommon.png",
+          "baseImageChecked" : "/interface/crafting/sortcommonselected.png",
+          "data" : {
+            "rarity" : [ "common" ]
+          }
+        },
+        {
+          "position" : [12, 60],
+          "baseImage" : "/interface/crafting/sortuncommon.png",
+          "baseImageChecked" : "/interface/crafting/sortuncommonselected.png",
+          "data" : {
+            "rarity" : [ "uncommon" ]
+          }
+        },
+        {
+          "position" : [18, 60],
+          "baseImage" : "/interface/crafting/sortrare.png",
+          "baseImageChecked" : "/interface/crafting/sortrareselected.png",
+          "data" : {
+            "rarity" : [ "rare" ]
+          }
+        },
+        {
+          "position" : [24, 60],
+          "baseImage" : "/interface/crafting/sortlegendary.png",
+          "baseImageChecked" : "/interface/crafting/sortlegendaryselected.png",
+          "data" : {
+            "rarity" : [ "legendary" ]
+          }
+        }
       ]
     }
   }


### PR DESCRIPTION
Add missing rarity buttons to avaliloom and avalidisplayapparatus to make their UI consistent with the other Avali crafting stations, as well as due to some other mod(s) expecting said consistency.